### PR TITLE
Fix underscore in iconlink

### DIFF
--- a/chicv.typ
+++ b/chicv.typ
@@ -8,7 +8,11 @@
 
 #let iconlink(
   uri, text: "", icon: link-icon) = {
-  link(uri)[#fa[#icon] #text]
+  if text != "" {
+    link(uri)[#fa[#icon] #text]
+  } else {
+    link(uri)[#fa[#icon]]
+  }
 }
 
 #let cventry(


### PR DESCRIPTION
Remove underscore if text is empty.

e.g.:

<img width="930" alt="Screenshot 2023-09-04 at 5 25 56 PM" src="https://github.com/matchy233/typst-chi-cv-template/assets/28824352/f268a775-8e3f-4aa4-b95c-a9487fc1c458">
