### PR TITLE
fix: change type matching in to-string function

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Assume that you have installed `typst` cli already and it's in your `$PATH`.
 ```bash
 git clone https://github.com/matchy233/typst-chi-cv-template.git
 cd typst-chi-cv-template
-typst compile --font-path ./fonts ./template/resume.typ resume.pdf
+typst compile --root ./ --font-path ./fonts ./template/resume.typ resume.pdf
 ```
 
 ## Usage

--- a/src/chicv.typ
+++ b/src/chicv.typ
@@ -8,9 +8,9 @@
 )
 
 #let to-string(input) = {
-  if type(input) == "string" {
+  if type(input) == str {
     input
-  } else if type(input) == "content" {
+  } else if type(input) == content {
     if input.has("text") {
       input.text
     } else if input.has("children") {
@@ -23,6 +23,8 @@
       // fallback, I don't know how to handle this input
       input
     }
+  } else {
+    str(input)
   }
 }
 


### PR DESCRIPTION
See detail in commit message.

Change the source branch from `main` to `patch-1` comparing to https://github.com/matchy233/typst-chi-cv-template/pull/12.